### PR TITLE
bump: update spring-boot-dependencies to 3.3.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <os-core-common.version>3.5.2</os-core-common.version>
 
     <!-- Spring Versions-->
-    <spring-boot.version>3.3.7</spring-boot.version>
+    <spring-boot.version>3.3.13</spring-boot.version>
     <spring-security.version>6.5.1</spring-security.version>
     <spring-framework.version>6.2.9</spring-framework.version>
 


### PR DESCRIPTION
Update Spring Boot version from 3.3.7 to 3.3.13 for security and bug fixes as requested in issue #21.

This is a conservative patch update that provides:
- Security fixes and vulnerability patches
- Bug fixes and stability improvements
- Maintains compatibility with existing codebase

Resolves #21