### PR TITLE
test(ci): 🚫 DO NOT MERGE — prove 🐳 Docker Build gate blocks a broken build (W10)

### DIFF
--- a/partition-core/src/main/java/org/opengroup/osdu/partition/controller/HealthCheckController.java
+++ b/partition-core/src/main/java/org/opengroup/osdu/partition/controller/HealthCheckController.java
@@ -28,4 +28,8 @@ public class HealthCheckController implements HealthCheckApi {
   public ResponseEntity<String> livenessCheck() {
     return new ResponseEntity<>("Partition service is alive.", HttpStatus.OK);
   }
+
+  // W10 CI-gate proof: intentional compile error to verify the required "🐳 Docker Build"
+  // check fails and blocks the merge. THIS PR MUST NOT BE MERGED.
+  this is an intentional syntax error to break the build;
 }


### PR DESCRIPTION
**Throwaway proof PR — must never merge; will be closed once the gate is observed blocking.**

Intentional compile error in `partition-core/.../HealthCheckController.java` to verify W10: the required `🐳 Docker Build` status check should report **FAILURE** (java-build fails → summary job fails) and leave the PR **BLOCKED** / unmergeable.

Expected:
- `🔨 Java Build` → failure
- `🐳 Docker Build` (required) → FAILURE
- `mergeStateStatus` → BLOCKED, merge refused